### PR TITLE
trying something out

### DIFF
--- a/.dbtignore
+++ b/.dbtignore
@@ -1,0 +1,4 @@
+*
+!macros/
+!dbt_project.yml
+!README.md


### PR DESCRIPTION
I need to see if this will work to prevent things from being saved in the deps folder in a dbt installation.

I'm skeptical this will work-- `.dbtignore` appears to work through the manifest stage only, and it's not clear to me that dbt deps uses this stage as part of how it downloads, copies, and parses the contents of a dbt project.

The reason I'm interested in this is actually less due to this project, and more due to another project that downloads a 3.3MB `.gif`, and I really don't want it doing that.

If this doesn't work (which is what I expect), I'm considering opening a feature PR in `dbt-core`.