### PR TITLE
Add redshift specific coefficient return function

### DIFF
--- a/macros/linear_regression/utils.sql
+++ b/macros/linear_regression/utils.sql
@@ -177,6 +177,14 @@ gb{{ loop.index }} as {{ gb }},
   {% endif %}
 {% endmacro %}
 
+{% macro redshift___maybe_round(x, round_) %}
+  {% if round_ is not none %}
+    {{ return('round(' ~ x ~ ', ' ~ round_ ~ ')') }}
+  {% else %}
+    {{ return(x) }}
+  {% endif %}
+{% endmacro %}
+
 {# Alias and write group by columns in a standard way. #}
 {% macro _gb_cols(group_by, trailing_comma=False, prefix=None) -%}
 {%- if group_by %}


### PR DESCRIPTION
Redshift doesn't include the same functionality with the numeric data type as postgres; returning unintended integers. This specific adapter for redshift allows continuous variables to be returned.